### PR TITLE
When debugging specify `--verbose` when installing default node / yarn.

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -102,12 +102,30 @@ async function setupVolta(version: string, toolPath: string): Promise<void> {
   }
 }
 
+export async function execVolta(specifiedArgs: string[]): Promise<void> {
+  const args = [...specifiedArgs];
+  let options;
+
+  if (core.isDebug()) {
+    args.unshift('--verbose');
+
+    options = {
+      env: {
+        VOLTA_LOGLEVEL: 'debug',
+        RUST_STACKTRACE: 'full',
+      },
+    };
+  }
+
+  await exec('volta', args, options);
+}
+
 export async function installNode(version: string): Promise<void> {
-  await exec('volta', ['install', `node${version === 'true' ? '' : `@${version}`}`]);
+  await execVolta(['install', `node${version === 'true' ? '' : `@${version}`}`]);
 }
 
 export async function installYarn(version: string): Promise<void> {
-  await exec('volta', ['install', `yarn${version === 'true' ? '' : `@${version}`}`]);
+  await execVolta(['install', `yarn${version === 'true' ? '' : `@${version}`}`]);
 }
 
 export async function getVolta(versionSpec: string): Promise<void> {


### PR DESCRIPTION
Leverages `core.isDebug()` which is the recommended way to ensure your action emits additional debugging information. The normal way to set that up is via `ACTION_STEP_DEBUG=true` (often setup in the repos own `secrets` in settings).