### PR TITLE
Avoid GitHub rate limiting when using `volta install yarn@1`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -106,7 +106,7 @@ jobs:
       with:
         volta-version: 0.7.2
         node-version: 12
-        yarn-version: 1.22
+        yarn-version: 1.22.4
 
     - run: volta --version
     - run: volta install node@10 yarn


### PR DESCRIPTION
When using a SemVer range for `yarn` volta will download from `api.github.com` (to get the list of releases to match the specified SemVer constraint against). Unfortunately, this cause rate limiting (since all GH Actions hosts are _effectively_ sharing IP addresses) and the requests fail.

See https://github.com/volta-cli/volta/issues/678 for reverting this.